### PR TITLE
LocalStorageを使って認証情報を保存、且つ初回マウント時に復元できるよう実装

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,20 +1,45 @@
 "use client";
 
-import { createContext, useState } from "react";
+import { createContext, useState, useEffect } from "react";
+
+interface AuthHeaders {
+  accessToken: string;
+  client: string;
+  uid: string;
+}
 
 type AuthContextType = {
-  authHeaders: {
-    accessToken: string;
-    client: string;
-    uid: string;
-  } | null;
-  setAuthHeaders: (headers: AuthContextType["authHeaders"]) => void;
+  authHeaders: AuthHeaders | null;
+  setAuthHeaders: (headers: AuthHeaders | null) => void;
 };
 
 export const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
-  const [authHeaders, setAuthHeaders] = useState<AuthContextType["authHeaders"]>(null);
+  const [authHeaders, setAuthHeadersState] = useState<AuthHeaders | null>(null);
+
+  // Context状態 と localStorage の両方に認証情報を保存する関数
+  const setAuthHeaders = (headers: AuthHeaders | null) => {
+    setAuthHeadersState(headers);
+    if (headers) {
+      localStorage.setItem("authHeaders", JSON.stringify(headers));
+    } else {
+      localStorage.removeItem("authHeaders");
+    }
+  };
+
+  // 初回マウント時に localStorage から認証情報を復元
+  useEffect(() => {
+    const stored = localStorage.getItem("authHeaders");
+    if (stored) {
+      try {
+        const parsed = JSON.parse(stored) as AuthHeaders;
+        setAuthHeadersState(parsed);
+      } catch (e) {
+        console.error("認証情報の読み込みに失敗しました", e);
+      }
+    }
+  }, []);
 
   return (
     <AuthContext.Provider value={{ authHeaders, setAuthHeaders }}>


### PR DESCRIPTION
下記、実装済み

- 認証情報（`authHeaders`）をローカルストレージに保存する処理
- 認証情報（`authHeaders`）をローカルストレージから削除する処理（サインアウト用）
- `useEffect`で、ページ初回マウント時にローカルストレージから認証情報を復元する処理

ブラウザで挙動確認
- サインインでローカルストレージに認証情報の保存OK
- ページ遷移しても認証情報が失われないこと（サインイン状態が継続）確認OK

closes #38 

