### PR TITLE
材料・調味料でname, amountの両方が空の行はRailsへ送信できないよう修正

### DIFF
--- a/src/utils/mapItems.ts
+++ b/src/utils/mapItems.ts
@@ -3,7 +3,9 @@ import { ItemEntry } from "@/types/recipe";
 
 // 材料 or 調味料 の入力値を map で処理
 export const mapItems = (items: ItemEntry[], category: "ingredient" | "seasoning") => {
-  return items.map((item) => {
+  return items
+  .filter((item) => item.name.trim() !== "" || item.amount.trim() !== "") // name と amount どちらも空の行は除外
+  .map((item) => {
     const { quantity, unit } = parseAmountToQuantityAndUnit(item.amount);
     return {
       name: item.name,


### PR DESCRIPTION
map前に`filter`で空行を除外する処理を追加

ブラウザで挙動チェック
- 空行の除外OK
- 材料と調味料どちらの場合も、`name` or `amount`の入力がなければ送信不可を確認

closes #58 