### PR TITLE
Contextの型定義をtype -> interfaceに変更

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -8,12 +8,12 @@ interface AuthHeaders {
   uid: string;
 }
 
-type AuthContextType = {
+interface AuthContextType {
   authHeaders: AuthHeaders | null;
   userId: number | null;
   setAuthHeaders: (headers: AuthHeaders | null) => void;
   setUserId: (id: number | null) => void;
-};
+}
 
 export const AuthContext = createContext<AuthContextType | undefined>(undefined);
 


### PR DESCRIPTION
プロジェクトで一貫性を保つため。オブジェクトは`interface`で型定義するよう統一する。