### PR TITLE
レシピ詳細ページで削除処理を追加

### DIFF
--- a/src/app/recipes/[recipeId]/page.tsx
+++ b/src/app/recipes/[recipeId]/page.tsx
@@ -3,21 +3,30 @@
 import { useState, useEffect } from "react";
 import { useRequireAuth } from "@/hooks/useRequireAuth";
 import { useApiClient } from "@/hooks/useApiClient";
-import { useParams } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import { formatAmount } from "@/utils/formatAmount";
 import { handleClientError } from "@/utils/handleClientError";
 import { Recipe } from "@/types/recipe";
+import { apiResult } from "@/types/api";
+import { showSuccessToast } from "@/components/ui/shadcn/sonner";
+import { Dialog, DialogContent, DialogHeader, DialogFooter, DialogTitle } from "@/components/ui/shadcn/dialog";
 import IngredientFields from "@/components/recipes/IngredientFields";
 import SeasoningFields from "@/components/recipes/SeasoningFields";
 import VideoDisplay from "@/components/recipes/VideoDisplay";
 import InputField from "@/components/ui/InputField";
+import Link from "next/link";
+import Button from "@/components/ui/Button";
 
 export default function RecipeShowPage() {
   useRequireAuth(); // 未認証ならリダイレクト
 
   const [recipe, setRecipe] = useState<Recipe | null>(null);
+  const [deleteId, setDeleteId] = useState<number | null>(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
   const { request, userId } = useApiClient();
   const { recipeId } = useParams();
+  const router = useRouter();
 
   // レシピ詳細の取得処理
   useEffect(() => {
@@ -49,22 +58,65 @@ export default function RecipeShowPage() {
   const displayedIngredients = ingredients.length > 0 ? ingredients : [{ id: "dummy", name: "", quantity: null, unit: "", category: "ingredient" }];
   const displayedSeasonings = seasonings.length > 0 ? seasonings : [{ id: "dummy", name: "", quantity: null, unit: "", category: "seasoning" }];
 
+  // レシピの削除処理
+  const deleteRecipe = async () => {
+  if (!deleteId) return;
+
+  try {
+    const res = await request<apiResult>(`/api/v1/users/${userId}/recipes/${deleteId}`, "DELETE");
+
+    if (res.ok) {
+      showSuccessToast(res.data.message || "レシピが削除されました");
+      router.push("/recipes/index");
+    } else {
+      handleClientError(res.status, res.data.error);
+    }
+  } catch (e) {
+    if (process.env.NODE_ENV !== "production") {
+      console.error("APIエラー:", e)
+    }
+  } finally {
+    closeDeleteModal();
+  }
+};
+
+  // レシピIDをnumber型に変換の上、削除モーダルへ渡す
+  const handleClickDelete = () => {
+    if (!recipeId || Array.isArray(recipeId)) return;
+    const idNumber = Number(recipeId);
+    if (isNaN(idNumber)) return;
+    openDeleteModal(idNumber);
+  };
+
+  const openDeleteModal = (id: number) => {
+    setDeleteId(id);
+    setIsModalOpen(true);
+  };
+
+  const closeDeleteModal = () => {
+    setDeleteId(null);
+    setIsModalOpen(false);
+  };
+
   return (
     <div className="max-w-3xl mx-auto space-y-12 py-12 px-4">
       <div className="flex justify-between items-center">
         <button
+          onClick={() => router.push("/recipes/index")}
           className="bg-gray-700 text-white px-4 py-2 rounded-md border border-transparent hover:bg-gray-800 transition"
         >
           レシピ一覧へ
         </button>
-        <div className="flex space-x-4">
-          <button
-            className="bg-green-600 text-white px-4 py-2 rounded-md border border-transparent hover:bg-gray-700 transition"
+        <div className="flex space-x-4 items-center">
+          <Link
+            href={`/recipes/${recipeId}/edit`}
+            className="text-lg text-green-600 mr-2 hover:underline"
           >
             編集
-          </button>
+          </Link>
           <button
-            className="bg-red-600 text-white px-4 py-2 rounded-md border border-transparent hover:bg-red-700 transition"
+            onClick={handleClickDelete}
+            className="text-lg text-red-600 hover:underline"
           >
             削除
           </button>
@@ -138,6 +190,23 @@ export default function RecipeShowPage() {
       <div className="max-w-2xl mx-auto space-y-8 pt-12 pb-24">
         <VideoDisplay video={recipe?.video ?? null} />
       </div>
+
+      {/* 削除モーダル */}
+      <Dialog open={isModalOpen} onOpenChange={setIsModalOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>レシピを削除しますか？</DialogTitle>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={closeDeleteModal}>
+              キャンセル
+            </Button>
+            <Button variant="destructive" onClick={deleteRecipe}>
+              削除
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }


### PR DESCRIPTION
下記、実装済み

- レシピのDELETEリクエストを追加
  - 削除モーダル追加
  - `useState`による _モーダル_ と _deleteId_ の状態管理を追加
- 「レシピ一覧へ」「編集」を押下した際にページ遷移するよう追記

ブラウザで動作確認OK

closes #103 