### PR TITLE
認証後、URL直打ちでページアクセスすると401エラーでリダイレクトされるバグを解消

### DIFF
--- a/src/app/recipes/[recipeId]/edit/page.tsx
+++ b/src/app/recipes/[recipeId]/edit/page.tsx
@@ -35,7 +35,7 @@ export default function RecipeEditPage() {
   // 初期データ取得
   useEffect(() => {
     const fetchRecipe = async () => {
-      if (!recipeId) return;
+      if (!userId || !recipeId) return;
 
       try {
         const res = await request<{ recipe: Recipe }>(`/api/v1/users/${userId}/recipes/${recipeId}`, "GET");

--- a/src/app/recipes/[recipeId]/page.tsx
+++ b/src/app/recipes/[recipeId]/page.tsx
@@ -32,7 +32,7 @@ export default function RecipeShowPage() {
   // レシピ詳細の取得処理
   useEffect(() => {
     const fetchRecipe = async () => {
-      if (!recipeId) return;
+      if (!userId || !recipeId) return;
 
       try {
         const res = await request<{ recipe: Recipe }>(`/api/v1/users/${userId}/recipes/${recipeId}`, "GET");


### PR DESCRIPTION
レシピ詳細画面 / レシピ編集画面 で発生
- 両ページの初回マウント時（`useEffect`）に**ユーザーID**がなければリターンで処理終了するよう追記

ブラウザで動作確認 -> バグ解消OK

fixes #107 