### PR TITLE
YouTube Data APIからの取得サムネイル画質をhighに変更

### DIFF
--- a/src/components/recipes/VideoEmbedBlock.tsx
+++ b/src/components/recipes/VideoEmbedBlock.tsx
@@ -31,7 +31,9 @@ export default function VideoEmbedBlock({ videoInfo, setVideoInfo, onDelete, onR
     return {
       video_id: videoId,
       etag: item.etag,
-      thumbnail_url: item.snippet.thumbnails?.medium?.url ?? "",
+      thumbnail_url: item.snippet.thumbnails?.high?.url
+                  ?? item.snippet.thumbnails?.medium?.url
+                  ?? "",
       status: item.status.privacyStatus,
       is_embeddable: item.status.embeddable,
       is_deleted: false,


### PR DESCRIPTION
第一優先は**high**、フォールバックとして**medium**を取得

ブラウザで動作確認OK -> 一覧ページである程度綺麗にサムネイル表示されていること確認

さらに画質上げるとページロード時間が長くなる & モバイルで過剰画質
よって、現状は**high**で運用する

closes #137 