### PR TITLE
パスワード変更ページでバリデーションエラーメッセージの表示処理を追加

### DIFF
--- a/src/app/(auth)/password-change/page.tsx
+++ b/src/app/(auth)/password-change/page.tsx
@@ -8,6 +8,12 @@ import { showSuccessToast } from "@/components/ui/shadcn/sonner";
 import InputField from "@/components/ui/InputField";
 import Button from "@/components/ui/Button";
 
+interface PasswordChangeErrorResponse {
+  current_password?: string[];
+  password?: string[];
+  password_confirmation?: string[];
+}
+
 const PasswordChangePage = () => {
   useRequireAuth(); // 未認証ならリダイレクト
 
@@ -15,6 +21,7 @@ const PasswordChangePage = () => {
   const [newPassword, setNewPassword] = useState("");
   const [newPasswordConfirmation, setNewPasswordConfirmation] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [fieldErrors, setFieldErrors] = useState<PasswordChangeErrorResponse>({});
 
   const { request } = useApiClient();
   const { handleClientError } = useClientErrorHandler();
@@ -25,6 +32,7 @@ const PasswordChangePage = () => {
     if (isSubmitting) return; // 二重送信防止
 
     setIsSubmitting(true);
+    setFieldErrors({});
 
     try {
       const payload = {
@@ -42,7 +50,17 @@ const PasswordChangePage = () => {
         setNewPassword("");
         setNewPasswordConfirmation("");
       } else {
-        handleClientError(res.status);
+        if (res.status === 422) {
+          const errors = res.data?.errors as PasswordChangeErrorResponse;
+
+          setFieldErrors({
+            current_password: errors.current_password ?? [],
+            password: errors.password ?? [],
+            password_confirmation: errors.password_confirmation ?? [],
+          });
+        } else {
+          handleClientError(res.status);
+        }
       }
     } catch (e) {
       if (process.env.NODE_ENV !== "production") {
@@ -63,22 +81,34 @@ const PasswordChangePage = () => {
             type="password"
             placeholder="現在のパスワード"
             value={currentPassword}
-            onChange={(e) => setCurrentPassword(e.target.value)}
+            onChange={(e) => {
+              setCurrentPassword(e.target.value);
+              setFieldErrors((prev) => ({ ...prev, current_password: [] }));
+            }}
             required
+            errorMessages={fieldErrors.current_password}
           />
           <InputField
             type="password"
             placeholder="新しいパスワード"
             value={newPassword}
-            onChange={(e) => setNewPassword(e.target.value)}
+            onChange={(e) => {
+              setNewPassword(e.target.value);
+              setFieldErrors((prev) => ({ ...prev, password: [] }));
+            }}
             required
+            errorMessages={fieldErrors.password}
           />
           <InputField
             type="password"
             placeholder="新しいパスワード確認用"
             value={newPasswordConfirmation}
-            onChange={(e) => setNewPasswordConfirmation(e.target.value)}
+            onChange={(e) => {
+              setNewPasswordConfirmation(e.target.value);
+              setFieldErrors((prev) => ({ ...prev, password_confirmation: [] }));
+            }}
             required
+            errorMessages={fieldErrors.password_confirmation}
           />
         </div>
 


### PR DESCRIPTION
下記、実装済み

- 各フィールドのエラー状態をuseStateで管理
- `InputField`コンポーネントにエラー状態やsetState関数を`props`として渡す

Railsで**current_password**のエラーメッセージを編集済み

ブラウザで動作確認OK

closes #157 