### PR TITLE
アカウント認証後、トップページへリダイレクト時に成功トーストを表示する

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,12 +1,30 @@
 "use client";
 
-import { useContext } from "react";
+import { useContext, useEffect } from "react";
 import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
 import { Plus } from "lucide-react";
 import { AuthContext } from "@/contexts/AuthContext";
+import { showSuccessToast } from "@/components/ui/shadcn/sonner";
 
 export default function Home() {
   const context = useContext(AuthContext);
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  // 認証完了クエリが存在する場合、成功トーストを表示
+  useEffect(() => {
+    const confirmed = searchParams.get("account_confirmation_success");
+    if (confirmed === "true") {
+      setTimeout(() => {
+        showSuccessToast("アカウントが正常に認証されました");
+      }, 0);
+
+      const newParams = new URLSearchParams(searchParams.toString());
+      newParams.delete("account_confirmation_success");
+      router.replace(`/?${newParams.toString()}`);
+    }
+  }, [searchParams]);
 
   // AuthProvider のラップ漏れチェック
   if (!context) {


### PR DESCRIPTION
下記、実装済み

- useEffectにてレンダー後のトースト表示処理
- `useSerachParams`でクエリパラメータを取得 & 認証成功を判定
  - `account_confirmation_success = true`なら成功トースト表示
  - トースト表示後は不要なパラメータ削除（純粋なトップページURLにリプレイス）

認証メールのリンク押下から動作確認OK

closes #169 