### PR TITLE
画像のドメイン許可設定を修正

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,7 +2,14 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   images: {
-    domains: ["i.ytimg.com"], // YouTubeのサムネイル画像のドメインを許可
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "i.ytimg.com", // YouTubeのサムネイル画像のドメインを許可
+        port: "",
+        pathname: "/**",
+      },
+    ],
   },
 };
 


### PR DESCRIPTION
YouTubeのサムネイル画像のドメイン許可について

`domains`が非推奨のため`remotePatterns`での指定に修正